### PR TITLE
Replaces astroconda-legacy-dev with real package (same code)

### DIFF
--- a/2016.2/hstdp-2016.2-linux-py35.2.txt
+++ b/2016.2/hstdp-2016.2-linux-py35.2.txt
@@ -20,7 +20,7 @@ http://ssb.stsci.edu/astroconda-legacy/linux-64/drizzlepac-2.1.3-np111py35_0.tar
 http://ssb.stsci.edu/astroconda-legacy/linux-64/fitsblender-0.2.6-np111py35_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/fontconfig-2.11.1-6.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/freetype-2.5.5-1.tar.bz2
-http://ssb.stsci.edu/astroconda-legacy-dev/linux-64/hstcal-1.0.1.dev20-1.tar.bz2
+http://ssb.stsci.edu/astroconda-legacy/linux-64/hstcal-1.1.1-1.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/imagesize-0.7.1-py35_0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/jbig-2.1-0.tar.bz2
 https://repo.continuum.io/pkgs/free/linux-64/jinja2-2.8-py35_1.tar.bz2


### PR DESCRIPTION
hstcal-1.1.1-1 is the same as hstcal-1.1.1rc1 delivered to the pipeline in iteration `1` (not listed here). The `0` iteration file pointed to an older broken build. 